### PR TITLE
add shmem save/restore of singleton Logger instance; example

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,8 @@ if(LIBLOGGER_COMPILE_EXAMPLE)
 	add_executable(liblogger-example logutil/logutil_example.cc)
 	target_link_libraries(liblogger-example PRIVATE liblogger)
 	set_target_properties(liblogger-example PROPERTIES OUTPUT_NAME logutil_example)
+	add_library(example_dylib SHARED logutil/logutil_example_dylib.cc)
+	target_link_libraries(example_dylib PRIVATE liblogger)
 endif()
 
 #option(LIBLOGGER_INSTALL "Install liblogger" ON)

--- a/logutil/logutil_example.cc
+++ b/logutil/logutil_example.cc
@@ -3,41 +3,66 @@
 // Created by deb on 11/23/19.
 //
 
-#include <fstream>
-#include <chrono>
-#include <ctime>
-#include <cstdlib>
+#include <dlfcn.h>
+
 #include <algorithm>
+#include <chrono>
+#include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
 
 #include "logutil.h"
 
 int main(int argc, char *argv[]) {
-	std::srand(std::time(nullptr));
-	auto &logger = Logger::get(); // default logger
+  std::srand(std::time(nullptr));
+  auto &logger = Logger::get();  // default logger
 
-	auto hd_logfile = std::ofstream{std::to_string(std::time(nullptr)) + ".txt"};
-	auto hd_logger = Logger{hd_logfile, hd_logfile};
-	hd_logger.setVerbosity(Logger::Verbosity::kTrace);
+  auto hd_logfile = std::ofstream{std::to_string(std::time(nullptr)) + ".txt"};
+  auto hd_logger = Logger{hd_logfile, hd_logfile};
+  hd_logger.setVerbosity(Logger::Verbosity::kTrace);
 
-	struct randInts {
-		randInts() = default;
-		explicit randInts(ssize_t n): n_{n} {}
-		bool operator ==(randInts const &rhs) const { return rhs.n_ == n_; }
-		bool operator !=(randInts const &rhs) const { return !(*this == rhs); }
-		randInts &operator++() { --n_; return *this; }
-		int operator*() const { return std::rand() * ((std::rand() % 2) ? -1 : 1); }
-		private: ssize_t n_{};
-	};
+  struct randInts {
+    randInts() = default;
+    explicit randInts(ssize_t n) : n_{n} {}
+    bool operator==(randInts const &rhs) const { return rhs.n_ == n_; }
+    bool operator!=(randInts const &rhs) const { return !(*this == rhs); }
+    randInts &operator++() {
+      --n_;
+      return *this;
+    }
+    int operator*() const { return std::rand() * ((std::rand() % 2) ? -1 : 1); }
 
-	std::for_each(randInts(5), randInts(), [&](int i) { // by-ref capture for 'logger'
-			// raw lines, console.debug alike, does not support fmt::format syntax
-			hd_logger.Trace("random integer:", i);
-			// using fmt::format
-			hd_logger.Trace(fmt::format("hig-res timestamp: {}ns", std::chrono::high_resolution_clock::now().time_since_epoch().count()));
+   private:
+    ssize_t n_{};
+  };
 
-		       	// managed logger, pretty prints
-			DEBUG("random int squared: {}", i*i);
-			// will not be output to stderr, since default logger's verbosity is DEBUG
-			TRACE("random int: {}", i);
-			});
+  std::for_each(
+      randInts(5), randInts(), [&](int i) {  // by-ref capture for 'logger'
+        // raw lines, console.debug alike, does not support fmt::format syntax
+        hd_logger.Trace("random integer:", i);
+        // using fmt::format
+        hd_logger.Trace(fmt::format("hig-res timestamp: {}ns",
+                                    std::chrono::high_resolution_clock::now()
+                                        .time_since_epoch()
+                                        .count()));
+
+        // managed logger, pretty prints
+        DEBUG("random int squared: {}", i * i);
+        // will not be output to stderr, since default logger's verbosity is
+        // DEBUG
+        TRACE("random int: {}", i);
+      });
+
+  logger.setVerbosity(Logger::Verbosity::kTrace);
+  TRACE("current dir: {}", std::filesystem::current_path().native());
+  auto *dlhandle = dlopen("./libexample_dylib.so", RTLD_NOW | RTLD_GLOBAL);
+  if (!dlhandle)
+    throw std::runtime_error(fmt::format("dlopen failed: {}", dlerror()));
+  void (*libmain_fn)() =
+      reinterpret_cast<void (*)()>(dlsym(dlhandle, "libmain"));
+  if (!libmain_fn)
+    throw std::runtime_error(fmt::format("dlsym failed: {}", dlerror()));
+  libmain_fn();
+  dlclose(dlhandle);
 }

--- a/logutil/logutil_example_dylib.cc
+++ b/logutil/logutil_example_dylib.cc
@@ -1,0 +1,7 @@
+#include "logutil.h"
+extern "C" void libmain() {
+  auto &logger = Logger::get();
+  TRACE(
+      "from example dylib: should inherit verbosity level trace from main "
+      "shared obj");
+}


### PR DESCRIPTION
this is so that plugins (compiled with own static version of logger) can share singleton logger instance and its settings and sync mutexes etc... with the main shared object (live_strategy/backtester).