### PR TITLE
Shmem inspector singleton

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,8 @@ if(LIBLOGGER_COMPILE_EXAMPLE)
 	set_target_properties(liblogger-example PROPERTIES OUTPUT_NAME logutil_example)
 	add_library(example_dylib SHARED logutil/logutil_example_dylib.cc)
 	target_link_libraries(example_dylib PRIVATE liblogger  -lrt)
+	target_compile_definitions(liblogger-example PRIVATE OVERRIDE_NDEBUG)
+	target_compile_definitions(example_dylib PRIVATE OVERRIDE_NDEBUG)
 endif()
 
 #option(LIBLOGGER_INSTALL "Install liblogger" ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,7 @@ endif()
 
 if(DEFINED ENV{VCPKG_ROOT})
 	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install --recurse
+		range-v3
 		boost-iostreams boost-iostreams[lzma]
 		gtest boost-lockfree curl
 		liblzma bzip2 zstd cpptrace)
@@ -58,6 +59,8 @@ find_package(Boost REQUIRED COMPONENTS iostreams)
 
 find_package(cpptrace CONFIG REQUIRED)
 
+find_package(range-v3 CONFIG REQUIRED)
+
 target_link_libraries(liblogger INTERFACE
 	chalk::chalk date::date
 	Threads::Threads ${CURL_LIBRARIES}
@@ -67,6 +70,7 @@ target_link_libraries(liblogger INTERFACE
 	$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
 	ZLIB::ZLIB
 	cpptrace::cpptrace
+	range-v3::meta range-v3::concepts range-v3::range-v3
 	)
 target_include_directories(liblogger INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include/liblogger>)
 #target_compile_options(liblogger INTERFACE ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,6 @@ set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_INCLUDE_CURRENT_DIR_IN_INTERFACE ON)
-set(CMAKE_CXX_FLAGS "-lrt")
 include(FetchContent)
 
 add_library(liblogger INTERFACE)
@@ -31,7 +30,6 @@ if (NOT TARGET date::date)
 	endif()
 endif()
 
-
 message(STATUS "[liblogger] Using system C++20 std::format")
 
 if (NOT TARGET Threads::Threads)
@@ -43,11 +41,15 @@ find_package(CURL REQUIRED)
 
 target_link_libraries(liblogger INTERFACE chalk::chalk date::date Threads::Threads ${CURL_LIBRARIES})
 target_include_directories(liblogger INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include/liblogger>)
-target_compile_options(liblogger INTERFACE -Wno-deprecated-declarations)
-target_sources(liblogger INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/logutil/logutil.h> $<INSTALL_INTERFACE:>)
-set_target_properties(liblogger PROPERTIES PUBLIC_HEADER "logutil.h;slack.h")
+#target_compile_options(liblogger INTERFACE ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations)
+target_sources(liblogger INTERFACE
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/logutil/logutil.h>
+	$<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}/inspector/inspector.hpp>
+	$<INSTALL_INTERFACE:>)
+set_target_properties(liblogger PROPERTIES PUBLIC_HEADER "logutil.h;slack.h;inspector.hpp")
 
 option(LIBLOGGER_COMPILE_EXAMPLE "Compile sample script" ON)
+
 if(LIBLOGGER_COMPILE_EXAMPLE)
 	add_executable(liblogger-example logutil/logutil_example.cc)
 	target_link_libraries(liblogger-example PRIVATE liblogger -lrt)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if (NOT TARGET date::date)
 endif()
 
 if(DEFINED ENV{VCPKG_ROOT})
-	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install boost-iostreams boost-iostreams[lzma] liblzma bzip2 zstd)
+	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install boost-iostreams boost-iostreams[lzma] liblzma bzip2 zstd cpptrace)
 endif()
 
 message(STATUS "[liblogger] Using system C++20 std::format")
@@ -53,6 +53,8 @@ find_package(ZLIB REQUIRED)
 
 find_package(Boost REQUIRED COMPONENTS iostreams)
 
+find_package(cpptrace CONFIG REQUIRED)
+
 target_link_libraries(liblogger INTERFACE
 	chalk::chalk date::date
 	Threads::Threads ${CURL_LIBRARIES}
@@ -61,6 +63,7 @@ target_link_libraries(liblogger INTERFACE
 	BZip2::BZip2
 	$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
 	ZLIB::ZLIB
+	cpptrace::cpptrace
 	)
 target_include_directories(liblogger INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include/liblogger>)
 #target_compile_options(liblogger INTERFACE ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,10 @@ if (NOT TARGET date::date)
 	endif()
 endif()
 
+if(DEFINED ENV{VCPKG_ROOT})
+	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install boost-iostreams boost-iostreams[lzma] liblzma)
+endif()
+
 message(STATUS "[liblogger] Using system C++20 std::format")
 
 if (NOT TARGET Threads::Threads)
@@ -39,7 +43,13 @@ endif()
 set(CURL_LIBRARY "-lcurl")
 find_package(CURL REQUIRED)
 
-target_link_libraries(liblogger INTERFACE chalk::chalk date::date Threads::Threads ${CURL_LIBRARIES})
+find_package(Boost REQUIRED COMPONENTS iostreams)
+
+target_link_libraries(liblogger INTERFACE
+	chalk::chalk date::date
+	Threads::Threads ${CURL_LIBRARIES}
+	Boost::boost Boost::iostreams
+	)
 target_include_directories(liblogger INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include/liblogger>)
 #target_compile_options(liblogger INTERFACE ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations)
 target_sources(liblogger INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,10 @@ if (NOT TARGET date::date)
 endif()
 
 if(DEFINED ENV{VCPKG_ROOT})
-	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install boost-iostreams boost-iostreams[lzma] liblzma bzip2 zstd cpptrace)
+	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install --recurse
+		boost-iostreams boost-iostreams[lzma]
+		boost-lockfree
+		liblzma bzip2 zstd cpptrace)
 endif()
 
 message(STATUS "[liblogger] Using system C++20 std::format")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,7 +31,7 @@ if (NOT TARGET date::date)
 endif()
 
 if(DEFINED ENV{VCPKG_ROOT})
-	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install boost-iostreams boost-iostreams[lzma] liblzma)
+	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install boost-iostreams boost-iostreams[lzma] liblzma bzip2 zstd)
 endif()
 
 message(STATUS "[liblogger] Using system C++20 std::format")
@@ -43,12 +43,24 @@ endif()
 set(CURL_LIBRARY "-lcurl")
 find_package(CURL REQUIRED)
 
+find_package(BZip2 REQUIRED)
+
+find_package(LibLZMA REQUIRED)
+
+find_package(zstd CONFIG REQUIRED)
+
+find_package(ZLIB REQUIRED)
+
 find_package(Boost REQUIRED COMPONENTS iostreams)
 
 target_link_libraries(liblogger INTERFACE
 	chalk::chalk date::date
 	Threads::Threads ${CURL_LIBRARIES}
 	Boost::boost Boost::iostreams
+	LibLZMA::LibLZMA
+	BZip2::BZip2
+	$<IF:$<TARGET_EXISTS:zstd::libzstd_shared>,zstd::libzstd_shared,zstd::libzstd_static>
+	ZLIB::ZLIB
 	)
 target_include_directories(liblogger INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}> $<INSTALL_INTERFACE:include/liblogger>)
 #target_compile_options(liblogger INTERFACE ${CMAKE_CXX_FLAGS} -Wno-deprecated-declarations)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 if(DEFINED ENV{VCPKG_ROOT})
 	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install --recurse
 		boost-iostreams boost-iostreams[lzma]
-		boost-lockfree curl
+		gtest boost-lockfree curl
 		liblzma bzip2 zstd cpptrace)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 if(DEFINED ENV{VCPKG_ROOT})
 	execute_process(COMMAND "$ENV{VCPKG_ROOT}/vcpkg" install --recurse
 		boost-iostreams boost-iostreams[lzma]
-		boost-lockfree
+		boost-lockfree curl
 		liblzma bzip2 zstd cpptrace)
 endif()
 

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -310,16 +310,18 @@ class INTST {
           }
 
           // Get the compression option from the config
-          auto compress = config->contains("save_internal_state_compress")
-                              ? (*config)["save_internal_state_compress"]
-                                    .get<std::string_view>()
-                              : "";
+          auto compress =
+              config && config->contains("save_internal_state_compress")
+                  ? (*config)["save_internal_state_compress"]
+                        .get<std::string_view>()
+                  : "";
 
           // Get the dump directory from the config
-          auto const dump_dir = config->contains("save_internal_state_basedir")
-                                    ? (*config)["save_internal_state_basedir"]
-                                          .get<std::string_view>()
-                                    : "/tmp";
+          auto const dump_dir =
+              config && config->contains("save_internal_state_basedir")
+                  ? (*config)["save_internal_state_basedir"]
+                        .get<std::string_view>()
+                  : "/tmp";
 
           // Generate the filename for the internal state dump
           auto const fname = std::format("{}/{}-internal.json{}", dump_dir,

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -226,7 +226,7 @@ class INTST {
    *     - "save_internal_state": Enable saving internal state.
    *     - "save_internal_state_compress": Compression format for the
    *       saved internal state (optional).
-   *     - "dump_dir": Directory to save the internal state dump (optional).
+   *     - "save_internal_state_basedir": Directory to save the internal state dump (optional).
    *
    * @return The singleton instance of INTST.
    */
@@ -274,8 +274,8 @@ class INTST {
 
           // Get the dump directory from the config
           auto const dump_dir =
-              config->contains("dump_dir")
-                  ? (*config)["dump_dir"].get<std::string_view>()
+              config->contains("save_internal_state_basedir")
+                  ? (*config)["save_internal_state_basedir"].get<std::string_view>()
                   : "/tmp";
 
           // Generate the filename for the internal state dump

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -13,6 +13,7 @@
 #include <boost/iostreams/filtering_stream.hpp>
 #include <cerrno>
 #include <chrono>
+#include <cpptrace.hpp>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
@@ -292,9 +293,19 @@ class INTST {
               !(*config)["save_internal_state"].get<bool>()) {
             fprintf(kCons, "%s\n",
                     std::format("{}:{}:{}: internal-state configuration not "
-                                "present or explicitly disabled",
-                                __FILE__, __LINE__, __PRETTY_FUNCTION__)
+                                "present or explicitly disabled: {}",
+                                __FILE__, __LINE__, __PRETTY_FUNCTION__,
+                                config ? config->dump() : "null")
                         .c_str());
+
+            auto btrace = cpptrace::generate_trace();
+
+            int line_count = 0;
+            for (auto &btentry : btrace) {
+              auto bt_line = btentry.to_string();
+              fprintf(kCons, "[INTST] %d: %s\n", ++line_count, bt_line.c_str());
+            }
+
             return new_intst;
           }
 

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -151,7 +151,7 @@ class INTST {
                         std::chrono::system_clock,
                         std::chrono::system_clock::duration>(chr_ts);
 
-                    cur_ts = isoDate(chr_tp);
+                    cur_ts = logutil::isoDate(chr_tp);
 
                     cur_kwargs.erase("timestamp");
                   }
@@ -328,7 +328,7 @@ class INTST {
 
           // Generate the filename for the internal state dump
           auto const fname = std::format("{}/{}-internal.json{}", dump_dir,
-                                         isoDate(), compress);
+                                         logutil::isoDate(), compress);
 
           // Create an output file stream for the dump file
           static std::unique_ptr<std::ofstream> out_stdfile{};

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -291,13 +291,15 @@ class INTST {
           // Check if config is null or if save_internal_state option is present
           if (config == nullptr || !config->contains("save_internal_state") ||
               !(*config)["save_internal_state"].get<bool>()) {
-            fprintf(kCons, "%s\n",
-                    std::format("{}:{}:{}: internal-state configuration not "
-                                "present or explicitly disabled: {}",
-                                __FILE__, __LINE__, __PRETTY_FUNCTION__,
-                                config ? config->dump() : "null")
-                        .c_str());
+            fprintf(
+                kCons, "%s\n",
+                std::format("{}:{}:{}: internal-state configuration not "
+                            "present or explicitly disabled",
+                            basename(__FILE__), __LINE__, __PRETTY_FUNCTION__,
+                            config ? config->dump() : "null")
+                    .c_str());
 
+#ifndef NDEBUG
             auto btrace = cpptrace::generate_trace();
 
             int line_count = 0;
@@ -305,6 +307,7 @@ class INTST {
               auto bt_line = btentry.to_string();
               fprintf(kCons, "[INTST] %d: %s\n", ++line_count, bt_line.c_str());
             }
+#endif
 
             return new_intst;
           }

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -293,7 +293,7 @@ class INTST {
           out_stdfile = std::make_unique<std::ofstream>(
               fname, std::ios::out | std::ios::trunc | std::ios::binary);
 
-          if (!out_stdfile || out_stdfile.get())
+          if (!out_stdfile || !*out_stdfile)
             throw std::runtime_error{
                 std::format("{}:{}: can't create file {}: {}", __FILE__,
                             __LINE__, fname, ::strerror(errno))};

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -56,7 +56,8 @@ class INTST {
 
  public:
   uint64_t era = 0;
-  nlohmann::json kwargs{};
+  nlohmann::json kwargs;
+
   // std::optional<int> internal_snapshot_fd_ = std::nullopt;
   std::shared_ptr<boost::iostreams::filtering_ostream> internal_snapshot_fd_{
       nullptr};

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -194,8 +194,7 @@ class INTST {
   void save_state_and_reset(double timestamp) {
     this->kwargs["era"] = era++;
 
-    static thread_local auto fmted_state_line =
-        this->kwargs.dump(-1)) + "\n";
+    static thread_local auto fmted_state_line = this->kwargs.dump(-1) + "\n";
 
     while (kwargs_mutex_->test_and_set(std::memory_order_acquire)) {
       while (kwargs_mutex_->test(std::memory_order_relaxed)) {
@@ -231,7 +230,7 @@ class INTST {
    *
    * @return The singleton instance of INTST.
    */
-  static auto get(nlohmann::json const *config) noexcept {
+  static std::shared_ptr<INTST> get(nlohmann::json const *config) noexcept {
     try {
       const static std::shared_ptr<INTST> kSingleton = [&]() {
         const auto mypid = getpid();
@@ -340,7 +339,7 @@ class INTST {
             "{}:{}:{}: shm_open(path='/{}-intst') failed: {}", __FILE__,
             __LINE__, __PRETTY_FUNCTION__, mypid, ::strerror(errno))};
       }();
-      return *kSingleton;
+      return kSingleton;
     } catch (std::exception const &err) {
       std::cerr << std::format(
           "{}:{}:{}: caught exception while constructing INTST singleton: "

--- a/inspector/inspector.hpp
+++ b/inspector/inspector.hpp
@@ -1,0 +1,352 @@
+#pragma once
+
+#include <fcntl.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include <atomic>
+#include <boost/iostreams/filter/bzip2.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filter/lzma.hpp>
+#include <boost/iostreams/filter/zstd.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <cerrno>
+#include <chrono>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <deque>
+#include <format>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <nlohmann/json.hpp>
+#include <stdexcept>
+#include <string_view>
+#include <thread>
+#include <utility>
+
+#include "../logutil/logutil.h"
+
+/**
+ * @class INTST
+ * @brief The INTST class represents an inspector that logs and saves internal
+ * state information.
+ *
+ * The INTST class is responsible for logging and saving internal state
+ * information. It provides a thread-safe mechanism for capturing and storing
+ * changes in the state of an object. The class uses a shared pointer to manage
+ * the internal snapshot file descriptor and provides methods for initializing
+ * the inspector, setting the file descriptor, saving the state, and retrieving
+ * the singleton instance.
+ *
+ * The INTST class uses a logger thread to continuously monitor the state
+ * changes and save them to the internal snapshot file. It supports compression
+ * options for the snapshot file and allows customization through a
+ * configuration object.
+ */
+class INTST {
+  static auto constexpr kFlushEveryNCycles = 1000;
+
+ public:
+  uint64_t era = 0;
+  nlohmann::json kwargs{};
+  // std::optional<int> internal_snapshot_fd_ = std::nullopt;
+  std::shared_ptr<boost::iostreams::filtering_ostream> internal_snapshot_fd_{
+      nullptr};
+
+  std::shared_ptr<std::atomic_flag> kwargs_mutex_ =
+      std::make_shared<std::atomic_flag>();
+  std::shared_ptr<std::atomic_bool> close_sig_ =
+      std::make_shared<std::atomic_bool>(false);
+  std::shared_ptr<std::deque<nlohmann::json>> kwargs_queue_ =
+      std::make_shared<std::deque<nlohmann::json>>();
+  std::shared_ptr<std::thread> logger_thread_ = nullptr;
+
+  FILE *cons_ = []() {
+    const int cons_fd = open("/dev/tty", O_WRONLY);
+    return cons_fd > -1 ? fdopen(cons_fd, "w") : stdout;
+  }();
+
+  ~INTST() {
+    // if (this->internal_snapshot_fd_.has_value())
+    //   ::close(this->internal_snapshot_fd_.value());
+    if (this->close_sig_ != nullptr) *(this->close_sig_) = true;
+    if (this->logger_thread_ && this->logger_thread_.use_count() == 1) {
+      // fmt::println(cons_, "Waiting form INTST logger thread to finish...");
+      this->logger_thread_->join();
+    }
+  }
+
+  INTST() = default;
+
+  void init() {
+    {
+      if (!this->logger_thread_)
+        this->logger_thread_ = std::make_shared<std::thread>(
+            [=, fd = internal_snapshot_fd_, cons_ = cons_] {
+              static thread_local nlohmann::json prev_kwargs{};
+              static thread_local nlohmann::json cur_kwargs{};
+
+              // fmt::println(cons_, "INTST thread started");
+
+            out_loop:
+              while (true) {
+                if (*close_sig_) break;
+
+                while (kwargs_mutex_->test_and_set(std::memory_order_acquire)) {
+                  while (kwargs_mutex_->test(std::memory_order_relaxed)) {
+                    if (*close_sig_) {
+                      kwargs_mutex_->clear();
+                      goto out_loop;
+                    }
+                  }
+                }
+
+                if (kwargs_queue_->empty()) {
+                  kwargs_mutex_->clear();
+                  constexpr auto kKwargsThreadSpinnerSleepDuration =
+                      std::chrono::milliseconds(10);
+
+                  std::this_thread::sleep_for(
+                      kKwargsThreadSpinnerSleepDuration);
+                  continue;
+                }
+
+                // fmt::println(cons_, "INTST thread: got KWARGS ({})",
+                //              kwargs_queue_->size());
+
+                while (!kwargs_queue_->empty()) {
+                  if (*close_sig_) {
+                    kwargs_mutex_->clear();
+                    goto out_loop;
+                  }
+
+                  nlohmann::json diff_kwargs{};
+
+                  {
+                    cur_kwargs = std::move(kwargs_queue_->front());
+                    kwargs_queue_->pop_front();
+                    kwargs_mutex_->clear();
+                  }
+
+                  std::optional<uint64_t> era = std::nullopt;
+                  std::optional<std::string> ts = std::nullopt;
+
+                  if (cur_kwargs.contains("era")) {
+                    era = cur_kwargs["era"].get<uint64_t>();
+                    cur_kwargs.erase("era");
+                  }
+
+                  if (cur_kwargs.contains("timestamp")) {
+                    const auto dbl_ts = cur_kwargs["timestamp"].get<double>();
+                    auto const chr_ts = std::chrono::duration_cast<
+                        std::chrono::system_clock::duration>(
+                        std::chrono::duration<double, std::ratio<1>>(dbl_ts));
+
+                    auto const chr_tp = std::chrono::time_point<
+                        std::chrono::system_clock,
+                        std::chrono::system_clock::duration>(chr_ts);
+
+                    ts = isoDate(chr_tp);
+
+                    cur_kwargs.erase("timestamp");
+                  }
+
+                  diff_kwargs =
+                      nlohmann::json::diff(prev_kwargs, cur_kwargs, "");
+
+                  prev_kwargs = std::move(cur_kwargs);
+
+                  if (diff_kwargs.empty()) {
+                    continue;
+                  }
+
+                  auto aug_kwargs = nlohmann::json::array({});
+                  if (era.has_value()) aug_kwargs.push_back(era.value());
+                  if (ts.has_value())
+                    aug_kwargs.emplace_back(std::move(ts.value()));
+                  aug_kwargs.emplace_back(std::move(diff_kwargs));
+
+                  auto fmted_kwargs = aug_kwargs.dump() + "\n\n";
+                  *fd << fmted_kwargs;
+
+                  if (era.has_value() && era.value() % kFlushEveryNCycles == 0)
+                    fd->flush();
+                }
+              }
+
+              // fmt::println(cons_,
+              //              "{}: main loop concluded. syncing output if
+              //              any...",
+              //              __PRETTY_FUNCTION__);
+              fd->flush();
+            });
+      this->logger_thread_->detach();
+    }
+  }
+
+  void set_fd(std::shared_ptr<boost::iostreams::filtering_ostream> bobf) {
+    this->internal_snapshot_fd_.swap(bobf);
+  }
+
+  void save_state_and_reset(double timestamp) {
+    this->kwargs["era"] = era++;
+
+    static thread_local auto fmted_state_line =
+        this->kwargs.dump(-1)) + "\n";
+
+    while (kwargs_mutex_->test_and_set(std::memory_order_acquire)) {
+      while (kwargs_mutex_->test(std::memory_order_relaxed)) {
+        // if (*this->close_sig_) break;
+      }
+    }
+
+    if (*this->close_sig_) {
+      // fmt::println(cons_, "EX:IT SIGNAL; KSWARG: {}", this->kwargs.dump());
+      kwargs_mutex_->clear();
+      return;
+    }
+
+    this->kwargs["timestamp"] = timestamp;
+    this->kwargs_queue_->push_back(std::move(this->kwargs));
+
+    kwargs_mutex_->clear();
+  }
+
+  /**
+   * @brief Singleton factory function to get the INTST instance.
+   *
+   * This function returns a singleton instance of INTST. It takes a config
+   * pointer as an argument, which can be used to customize the behavior of the
+   * INTST instance.
+   *
+   * @param config A pointer to a JSON object containing configuration options.
+   *     The following keys are accepted:
+   *     - "save_internal_state": Enable saving internal state.
+   *     - "save_internal_state_compress": Compression format for the
+   *       saved internal state (optional).
+   *     - "dump_dir": Directory to save the internal state dump (optional).
+   *
+   * @return The singleton instance of INTST.
+   */
+  static auto get(nlohmann::json const *config) noexcept {
+    try {
+      const static std::shared_ptr<INTST> kSingleton = [&]() {
+        const auto mypid = getpid();
+        constexpr auto kSzIntSt = sizeof(std::shared_ptr<INTST>);
+
+        // Create a shared memory segment for the singleton instance
+        if (const int shm_fd =
+                shm_open(std::format("/{}-intst", mypid).c_str(),
+                         O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+            shm_fd != -1) {
+          (void)ftruncate(shm_fd, kSzIntSt);
+
+          auto new_intst = std::make_shared<INTST>();
+
+          // Map the shared memory segment to the singleton instance
+          auto *p_intst = static_cast<std::shared_ptr<INTST> *>(
+              mmap(nullptr, kSzIntSt, PROT_READ | PROT_WRITE, MAP_SHARED,
+                   shm_fd, 0));
+
+          if (p_intst == MAP_FAILED)
+            throw std::runtime_error{std::format("{}:{}: shmlog mmap fail: {}",
+                                                 __FILE__, __LINE__,
+                                                 strerror(errno))};
+
+          *p_intst = new_intst;
+          close(shm_fd);
+          munmap(p_intst, kSzIntSt);
+
+          // Check if config is null or if save_internal_state option is present
+          if (config == nullptr || !config->contains("save_internal_state")) {
+            throw std::runtime_error{
+                std::format("{}:{}: pConfig cannot be null on first call",
+                            __FILE__, __LINE__)};
+          }
+
+          // Get the compression option from the config
+          auto compress = config->contains("save_internal_state_compress")
+                              ? (*config)["save_internal_state_compress"]
+                                    .get<std::string_view>()
+                              : "";
+
+          // Get the dump directory from the config
+          auto const dump_dir =
+              config->contains("dump_dir")
+                  ? (*config)["dump_dir"].get<std::string_view>()
+                  : "/tmp";
+
+          // Generate the filename for the internal state dump
+          auto const fname = std::format("{}/{}-internal.json{}", dump_dir,
+                                         isoDate(), compress);
+
+          // Create an output file stream for the dump file
+          static std::unique_ptr<std::ofstream> out_stdfile{};
+          out_stdfile = std::make_unique<std::ofstream>(
+              fname, std::ios::out | std::ios::trunc | std::ios::binary);
+
+          if (!out_stdfile || out_stdfile.get())
+            throw std::runtime_error{
+                std::format("{}:{}: can't create file {}: {}", __FILE__,
+                            __LINE__, fname, ::strerror(errno))};
+
+          // Create a filtering output stream with compression options
+          auto out_sbuf =
+              std::make_shared<boost::iostreams::filtering_ostream>();
+
+          if (compress == ".xz")
+            out_sbuf->push(boost::iostreams::lzma_compressor());
+          if (compress == ".gz")
+            out_sbuf->push(boost::iostreams::gzip_compressor());
+          if (compress == ".bz2")
+            out_sbuf->push(boost::iostreams::bzip2_compressor());
+          if (compress == ".zstd")
+            out_sbuf->push(boost::iostreams::zstd_compressor());
+
+          out_sbuf->push(*out_stdfile);
+
+          // Set the output stream for the INTST instance
+          new_intst->set_fd(std::move(out_sbuf));
+
+          new_intst->init();
+          return new_intst;
+        }
+
+        // If the shared memory segment already exists, restore the previous
+        // instance
+        if (const int shm_fd = shm_open(std::format("/{}-intst", mypid).c_str(),
+                                        O_RDWR, S_IRUSR | S_IWUSR);
+            shm_fd != -1) {
+          auto *p_intst = static_cast<std::shared_ptr<INTST> *>(
+              mmap(nullptr, kSzIntSt, PROT_READ | PROT_WRITE, MAP_SHARED,
+                   shm_fd, 0));
+
+          if (p_intst == MAP_FAILED)
+            throw std::runtime_error{std::format("{}:{}: shm-mmap fail: {}",
+                                                 __FILE__, __LINE__,
+                                                 ::strerror(errno))};
+
+          close(shm_fd);
+          auto prev_intst = *p_intst;
+          munmap(p_intst, kSzIntSt);
+
+          return prev_intst;
+        }
+
+        throw std::runtime_error{std::format(
+            "{}:{}:{}: shm_open(path='/{}-intst') failed: {}", __FILE__,
+            __LINE__, __PRETTY_FUNCTION__, mypid, ::strerror(errno))};
+      }();
+      return *kSingleton;
+    } catch (std::exception const &err) {
+      std::cerr << std::format(
+          "{}:{}:{}: caught exception while constructing INTST singleton: "
+          "{}\n",
+          __FILE__, __LINE__, __PRETTY_FUNCTION__, err.what());
+      std::terminate();
+    }
+  }
+};

--- a/logutil/logutil.h
+++ b/logutil/logutil.h
@@ -15,11 +15,177 @@
 #include <unistd.h>
 
 #include <chrono>
+#include <cstring>
 #include <format>
+#include <functional>
 #include <iostream>
-#include <sstream>
+#include <span>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
+#include <utility>
 
+#if (__cplusplus >= 202002L)
+template <ssize_t N>
+consteval auto _basename(const char (&path)[N]) {
+  ssize_t idx;
+  for (idx = N - 1; idx >= 0; --idx)
+    if (path[idx] == '/') break;
+  return &(path[idx + 1]);
+}
+#else
+inline const char *_basename(const char *path) {
+  const char *p = path + strlen(path);
+  while (p > path && *p != '/') --p;
+  return p == path ? path : p + 1;
+}
+#endif
+
+namespace logger {
+namespace details {
+
+template <typename... Args>
+static inline auto fmt_args(auto &&fmt_str, Args &&...args) {
+  return (std::vformat(std::forward<decltype(fmt_str)>(fmt_str),
+                       std::make_format_args(std::forward<Args>(args)...)));
+}
+
+namespace explode {
+template <uint8_t... Digits>
+struct PositiveToChars {
+  static const std::array<char, sizeof...(Digits) + 1> kValue;
+};
+template <uint8_t... Digits>
+constexpr std::array<char, sizeof...(Digits) + 1>
+    PositiveToChars<Digits...>::kValue = {('0' + Digits)..., 0};
+
+template <uint8_t... Digits>
+struct NegativeToChars {
+  static const std::array<char, sizeof...(Digits) + 2> kValue;
+};
+template <uint8_t... Digits>
+constexpr std::array<char, sizeof...(Digits) + 2>
+    NegativeToChars<Digits...>::kValue = {'-', ('0' + Digits)..., 0};
+
+template <bool Neg, uint8_t... Digits>
+struct ToChars : PositiveToChars<Digits...> {};
+
+template <uint8_t... Digits>
+struct ToChars<true, Digits...> : NegativeToChars<Digits...> {};
+
+template <bool Neg, uintmax_t Rem, uint8_t... Digits>
+struct Explode : Explode<Neg, Rem / 10, Rem % 10, Digits...> {};
+
+template <bool Neg, uint8_t... Digits>
+struct Explode<Neg, 0, Digits...> : ToChars<Neg, Digits...> {};
+
+template <typename T>
+constexpr uintmax_t cabs(T num) {
+  return (num < 0) ? -num : num;
+}
+}  // namespace explode
+
+template <typename Integer, Integer Num>
+struct StringFrom : explode::Explode<(Num < 0), explode::cabs(Num)> {};
+
+/// https://stackoverflow.com/a/68911826
+template <size_t N>
+struct PastLastSlash {
+  consteval PastLastSlash(const char (&src)[N]) {
+    std::string str{src};
+    auto pos = str.rfind('/');
+    if (pos == std::string::npos) {
+      pos = 0;
+    } else {
+      ++pos;
+    }
+    size_t len = str.length() - pos;
+    std::copy(src + pos, src + pos + len - 1, value.data());
+  }
+
+  [[nodiscard]] consteval size_t len() const {
+    std::string str{value.data()};
+    return str.length();
+  }
+
+  std::array<char, N - 1> value{};
+};
+}  // namespace details
+
+template <details::PastLastSlash S>
+struct PastLastSlash {
+  static consteval std::array<char, S.len() + 1> copy() {
+    std::array<char, S.len() + 1> arr{};
+    std::copy(S.value.data(), S.value.data() + S.len(), arr.data());
+    return arr;
+  }
+  static constexpr std::array<char, S.len() + 1> kArr{copy()};
+};
+
+template <ssize_t N>
+consteval std::string basename(const char (&path)[N]) {
+  ssize_t idx;
+  for (idx = N - 1; idx >= 0; --idx)
+    if (path[idx] == '/') break;
+  return (path + idx + 1);
+}
+
+template <std::size_t... Zs>
+constexpr std::string zstrcats(const std::array<char, Zs> &...strN)
+  requires(noexcept(strN[0]) && ...)
+{
+  std::array<char, (Zs + ...) - sizeof...(Zs) + 1> resv{};
+  size_t cat_idx = 0;
+  const auto cat_helper = [&](const auto &src) {
+    for (auto chr : src) resv[cat_idx++] = chr;
+    if (!src.empty()) cat_idx -= 1;
+  };
+
+  (void)(cat_helper(strN), ...);
+
+  return std::string{std::string_view(resv.data())};
+}
+
+template <typename... StrViews>
+constexpr std::string zstrcats(StrViews... strN) {
+  std::string zsum;
+
+  auto all_of_em = std::array<std::string, sizeof...(StrViews)>(
+      {std::string{strN.data()}...});
+
+  for (const auto &zstr : all_of_em) zsum += std::move(zstr);
+
+  return zsum;
+}
+
+template <size_t M>
+consteval std::array<char, M> zatoa(const char (&str1)[M])
+  requires(noexcept(str1[0]))
+{
+  std::array<char, M> resv{};
+  size_t conv_idx = 0;
+
+  for (auto chr : std::span(str1, M - 1)) resv[conv_idx++] = chr;
+  return resv;
+}
+
+template <size_t M>
+consteval std::array<char, M> zatoa(const std::array<char, M> &str1) {
+  std::array<char, M> resv{};
+  size_t conv_idx = 0;
+
+  for (auto chr : str1) resv[conv_idx++] = chr;
+  return resv;
+}
+
+// static constexpr auto zatoa(std::string str1) { return std::move(str1); }
+constexpr auto zatoa(std::string_view str1) {
+  // return str1;
+  auto new_str = std::string{str1.begin(), str1.end()};
+  return std::move(new_str);
+}
+
+}  // namespace logger
 template <typename Clock = std::chrono::system_clock>
 static inline auto isoDate(std::chrono::time_point<Clock> tp = Clock::now())
     -> std::string {
@@ -30,43 +196,53 @@ static inline auto isoDate(std::chrono::time_point<Clock> tp = Clock::now())
 struct Logger {
   explicit Logger(std::ostream &ost = std::cout, std::ostream &est = std::cerr)
       : outStream_{&ost}, errStream_{&est} {}
-  template <typename... _Args>
-  auto Info(const _Args &...args) -> std::ostream & {
-    return (verbosity_ >= Verbosity::kInfo)
-               ? output(std::chrono::system_clock::now(), outStream_,
-                        kInfoChalk, "[II]", args...)
-               : *outStream_;
+
+  template <typename... Args>
+  inline auto Info(Args &&...args) {
+    if (verbosity_ >= Verbosity::kInfo)
+      output(std::chrono::system_clock::now(), outStream_, kInfoChalk,
+             std::forward<Args>(args)...);
   }
 
-  template <typename... _Args>
-  auto Warn(const _Args &...args) -> std::ostream & {
-    return (verbosity_ >= Verbosity::kWarn)
-               ? output(std::chrono::system_clock::now(), outStream_,
-                        kWarnChalk, "[WW]", args...)
-               : *outStream_;
+  template <const char *FmtStr, typename... Args>
+  inline auto InfoConstFmt(Args &&...args) {
+    if (verbosity_ >= Verbosity::kInfo)
+      output<FmtStr>(std::chrono::system_clock::now(), outStream_, kInfoChalk,
+                     std::forward<Args>(args)...);
   }
 
-  template <typename... _Args>
-  auto Error(const _Args &...args) -> std::ostream & {
-    return (verbosity_ >= Verbosity::kErr)
-               ? output(std::chrono::system_clock::now(), errStream_,
-                        kErrorChalk, "[EE]", args...)
-               : *errStream_;
+  template <typename... Args>
+  inline auto Warn(Args &&...args) {
+    if (verbosity_ >= Verbosity::kWarn)
+      output(std::chrono::system_clock::now(), outStream_, kWarnChalk,
+             std::forward<Args>(args)...);
   }
-  template <typename... _Args>
-  auto Debug(const _Args &...args) -> std::ostream & {
-    return (verbosity_ >= Verbosity::kDebug)
-               ? output(std::chrono::system_clock::now(), errStream_,
-                        kDebugChalk, "[DD]", args...)
-               : *errStream_;
+
+  template <typename... Args>
+  inline auto Error(Args &&...args) {
+    if (verbosity_ >= Verbosity::kErr)
+      output(std::chrono::system_clock::now(), errStream_, kErrorChalk,
+             std::forward<Args>(args)...);
   }
-  template <typename... _Args>
-  auto Trace(const _Args &...args) -> std::ostream & {
-    return (verbosity_ >= Verbosity::kTrace)
-               ? output(std::chrono::system_clock::now(), errStream_,
-                        kTraceChalk, "[TT]", args...)
-               : *errStream_;
+
+  template <typename... Args>
+  inline auto Debug(Args &&...args) {
+    if (verbosity_ >= Verbosity::kDebug)
+      output(std::chrono::system_clock::now(), errStream_, kDebugChalk,
+             std::forward<Args>(args)...);
   }
+
+#ifndef NDEBUG
+  template <typename... Args>
+  inline auto Trace(Args &&...args) {
+    if (verbosity_ >= Verbosity::kTrace)
+      output(std::chrono::system_clock::now(), errStream_, kTraceChalk,
+             std::forward<Args>(args)...);
+  }
+#else
+  template <typename... Args>
+  inline auto Trace(Args &&...args) {}
+#endif
 
   void setUnifiedOutput(bool flag) { this->unified_output_ = flag; }
 
@@ -82,25 +258,21 @@ struct Logger {
   void setVerbosity(Verbosity verbosity) { verbosity_ = verbosity; }
 
  protected:
-  template <typename Clock, typename FmtType, typename... _Args>
-  auto output(std::chrono::time_point<Clock> &&tm, std::ostream *ost,
-              const FmtType &fmt = chalk::fg::White, const _Args &...args)
-      -> std::ostream & {
+  template <typename Clock, typename FmtType, typename... Args>
+  auto output(std::chrono::time_point<Clock> &&tpt, std::ostream *ost,
+              FmtType &&fmt, auto &&fmt_str, Args &&...args) {
     const std::chrono::duration<float> delta_t =
-        tm - ((ost == outStream_ && !this->unified_output_) ? lastTimes_[0]
-                                                            : lastTimes_[1]);
-    lastTimes_[(ost == outStream_ && !this->unified_output_) ? 0 : 1] = tm;
-    *ost << (kTsChalk(isoDate(tm)) + "  " + fmt(logN(args...)) + " +" +
-             kDtChalk(std::to_string(delta_t.count()) + "s") + "\n");
-    return *ost;
+        tpt - ((ost == outStream_ && !this->unified_output_) ? lastTimes_[0]
+                                                             : lastTimes_[1]);
+
+    lastTimes_[(ost == outStream_ && !this->unified_output_) ? 0 : 1] = tpt;
+
+    *ost << (kTsChalk(isoDate(tpt)) + "  " +
+             fmt(logger::details::fmt_args(
+                 std::forward<decltype(fmt_str)>(fmt_str),
+                 std::forward<Args>(args)...)) +
+             " +" + kDtChalk(std::to_string(delta_t.count()) + "s") + "\n");
   }
-  template <typename _Arg0, typename... Args>
-  auto logN(_Arg0 const &arg0, const Args &...args) -> std::string {
-    std::ostringstream oss{};
-    oss << " " << arg0;
-    return oss.str() + logN(args...);
-  }
-  static auto logN() -> std::string { return ""; }
 
  private:
   std::ostream *outStream_, *errStream_;
@@ -123,51 +295,88 @@ struct Logger {
 
  public:
   /**
-   * singleton style
+   * @brief Returns a reference to the Logger singleton.
+   *
+   * This function establishes a shared memory space to ensure multiple
+   * processes share a single Logger instance. It's particularly useful when
+   * separate shared objects, each containing a duplicate Logger instance due to
+   * being compiled with the same header, need a unified logging mechanism. This
+   * scenario often arises with runtime-linked components via `dlopen`.
+   *
+   * Process:
+   * 1. Check for an existing shared memory area for the Logger. If it exists,
+   *    map it into the current process's address space, retrieve the Logger
+   *    instance, and return it.
+   * 2. If no shared memory exists, create it and size it appropriately to store
+   *    the Logger instance.
+   * 3. Construct a new Logger in the shared memory.
+   * 4. Once the Logger is stored, close and unmap the shared memory.
+   * 5. Return the Logger instance.
+   *
+   * Errors during any step, such as failure to map or unmap the shared memory,
+   * trigger a runtime exception.
+   *
+   * @return A reference to the Logger singleton.
+   * @throws std::runtime_error if an error occurs during the process.
    */
   static auto get() noexcept -> Logger & {
     try {
-      static std::shared_ptr<Logger> singleton = []() {
-        auto mypid = getpid();
+      static auto singleton = []() {
+        auto my_pid = getpid();
         constexpr auto kSzLogger = sizeof(std::shared_ptr<Logger>);
-        if (int shm_fd = shm_open(std::format("/{}-logger", mypid).c_str(),
-                                  O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+
+        if (const int shm_fd =
+                shm_open(std::format("/{}-logger", my_pid).c_str(), O_RDWR,
+                         S_IRUSR | S_IWUSR);
             shm_fd != -1) {
-          ftruncate(shm_fd, kSzLogger);
-          auto new_logger = std::make_shared<Logger>();
-          auto *plogger = static_cast<std::shared_ptr<Logger> *>(
+          auto *mmapped_shm = static_cast<std::shared_ptr<Logger> *>(
               mmap(nullptr, kSzLogger, PROT_READ | PROT_WRITE, MAP_SHARED,
                    shm_fd, 0));
-          if (plogger == MAP_FAILED)
-            throw std::runtime_error{std::format("shmlog mmap fail")};
-          *plogger = new_logger;
+
+          if (mmapped_shm == MAP_FAILED)
+            throw std::runtime_error{std::format(
+                "{}:{}:{}: on-restore mmap of shm area failed: {}", __FILE__,
+                __LINE__, __PRETTY_FUNCTION__, strerror(errno))};
+
           close(shm_fd);
-          // std::clog << std::format(
-          //     "save logger shmem@/{}-logger; ptr={:p}; sptr.p={:p}\n", mypid,
-          //     (void *)(plogger), (void *)plogger->get());
-          munmap(plogger, kSzLogger);
-          return new_logger;
-        } else if (int shm_fd =
-                       shm_open(std::format("/{}-logger", mypid).c_str(),
-                                O_RDWR, S_IRUSR | S_IWUSR);
-                   shm_fd != -1) {
-          auto *plogger = static_cast<std::shared_ptr<Logger> *>(
-              mmap(nullptr, kSzLogger, PROT_READ | PROT_WRITE, MAP_SHARED,
-                   shm_fd, 0));
-          if (plogger == MAP_FAILED)
-            throw std::runtime_error{std::format("shmlog mmap fail")};
-          close(shm_fd);
-          auto prev_logger = *plogger;
-          // std::clog << std::format(
-          //     "restore logger shmem@/{}-logger; ptr={:p}; sptr.p={:p}\n",
-          //     mypid, (void *)(plogger), (void *)plogger->get());
-          munmap(plogger, kSzLogger);
+          auto prev_logger = *mmapped_shm;
+
+          munmap(mmapped_shm, kSzLogger);
           return prev_logger;
-        } else {
-          throw std::runtime_error{std::format("shm logger open: {}{}{}",
-                                               __FILE__, __LINE__, __func__)};
         }
-        // return std::make_unique<Logger>();
+
+        if (const int shm_fd =
+                shm_open(std::format("/{}-logger", my_pid).c_str(),
+                         O_CREAT | O_EXCL | O_RDWR, S_IRUSR | S_IWUSR);
+            shm_fd != -1) {
+          if (ftruncate(shm_fd, kSzLogger) == -1) {
+            throw std::runtime_error{
+                std::format("{}:{}:{}: ftruncate failed: {}", __FILE__,
+                            __LINE__, __PRETTY_FUNCTION__, strerror(errno))};
+          }
+          auto new_logger = std::make_shared<Logger>();
+
+          auto *mmapped_shm = static_cast<std::shared_ptr<Logger> *>(
+              mmap(nullptr, kSzLogger, PROT_READ | PROT_WRITE, MAP_SHARED,
+                   shm_fd, 0));
+
+          if (mmapped_shm == MAP_FAILED)
+            throw std::runtime_error{std::format(
+                "{}:{}:{}: on-create mmap of shm area failed: {}", __FILE__,
+                __LINE__, __PRETTY_FUNCTION__, strerror(errno))};
+
+          *mmapped_shm = new_logger;
+
+          close(shm_fd);
+          munmap(mmapped_shm, kSzLogger);
+
+          return new_logger;
+        }
+
+        throw std::runtime_error{
+            std::format("{}:{}:{}: unable to restore or create a new 'shm' "
+                        "handle for Logger",
+                        __FILE__, __LINE__, __PRETTY_FUNCTION__)};
       }();
       return *singleton;
     } catch (std::exception const &err) {
@@ -180,60 +389,77 @@ struct Logger {
   }
 };
 
-// extern Logger logger;
+// #define CONCAT(_a_, _b_) CONCAT_INNER(_a_, _b_)
+// #define CONCAT_INNER(_a_, _b_) _a_##_b_
+// #define UNIQUE_NAME(_base_) \
+//   CONCAT(CONCAT(CONCAT(_base_, __COUNTER__), _), __LINE__)
 
-#if (__cplusplus >= 202002L)
-template <ssize_t N>
-consteval auto _basename(const char (&path)[N]) -> const char * {
-  ssize_t i;
-  for (i = N - 1; i >= 0; --i)
-    if (path[i] == '/') break;
-  return &(path[i + 1]);
-}
-#else
-inline const char *_basename(const char *path) {
-  const char *p = path + strlen(path);
-  while (p > path && *p != '/') --p;
-  return p == path ? path : p + 1;
-}
-#endif
+#define QT(x) #x
+#define QUOTE(x) QT(x)
 
-using namespace std::string_literals;
-#define INFO(_fmt, ...)                                            \
-  do {                                                             \
-    logger.Info(std::format("[{}:{}:{}]: " _fmt, __func__,         \
-                            _basename(__FILE__),                   \
-                            __LINE__ __VA_OPT__(, ) __VA_ARGS__)); \
-  } while (false);
-#define ERROR(_fmt, ...)                                            \
-  do {                                                              \
-    logger.Error(std::format("[{}:{}:{}]: " _fmt, __func__,         \
-                             _basename(__FILE__),                   \
-                             __LINE__ __VA_OPT__(, ) __VA_ARGS__)); \
-  } while (false);
-#define WARN(_fmt, ...)                                            \
-  do {                                                             \
-    logger.Warn(std::format("[{}:{}:{}]: " _fmt, __func__,         \
-                            _basename(__FILE__),                   \
-                            __LINE__ __VA_OPT__(, ) __VA_ARGS__)); \
-  } while (false);
-#define DEBUG(_fmt, ...)                                            \
-  do {                                                              \
-    logger.Debug(std::format("[{}:{}:{}]: " _fmt, __func__,         \
-                             _basename(__FILE__),                   \
-                             __LINE__ __VA_OPT__(, ) __VA_ARGS__)); \
-  } while (false);
+// #include <type_traits>
+// #define IS_SL(x)                                                    \
+//   ([&]<class T = char>() {                                          \
+//     return std::is_same_v<decltype(x), T const(&)[sizeof(x)]> and   \
+//            requires { std::type_identity_t<T[sizeof(x) + 1]>{x}; }; \
+//   }())
+
+#define INFO(_fmt, ...)                                                        \
+  do {                                                                         \
+    logger.Info(                                                               \
+        logger::zstrcats(logger::zatoa("["),                                   \
+                         logger::zatoa(logger::PastLastSlash<__FILE__>::kArr), \
+                         logger::zatoa(":" QUOTE(__LINE__) ":"),               \
+                         logger::zatoa(__func__), logger::zatoa("]: [II] "),   \
+                         logger::zatoa(_fmt))                                  \
+                                                                               \
+            .data() __VA_OPT__(, ) __VA_ARGS__);                               \
+  } while (false)
+
+#define ERROR(_fmt, ...)                                                       \
+  do {                                                                         \
+    logger.Error(                                                              \
+        logger::zstrcats(logger::zatoa("[" __FILE__ ":" QUOTE(__LINE__) ":"),  \
+                         logger::zatoa(logger::PastLastSlash<__FILE__>::kArr), \
+                         logger::zatoa("]: [EE] "), logger::zatoa(_fmt))       \
+                                                                               \
+            .data() __VA_OPT__(, ) __VA_ARGS__);                               \
+  } while (false)
+
+#define WARN(_fmt, ...)                                                        \
+  do {                                                                         \
+    logger.Warn(                                                               \
+        logger::zstrcats(logger::zatoa("[" __func__ ":" QUOTE(__LINE__) ":"),  \
+                         logger::zatoa(logger::PastLastSlash<__FILE__>::kArr), \
+                         logger::zatoa("]: [WW] "), logger::zatoa(_fmt))       \
+                                                                               \
+            .data() __VA_OPT__(, ) __VA_ARGS__);                               \
+  } while (false)
+
+#define DEBUG(_fmt, ...)                                                       \
+  do {                                                                         \
+    logger.Debug(                                                              \
+        logger::zstrcats(logger::zatoa("[" __FILE__ ":" QUOTE(__LINE__) ":"),  \
+                         logger::zatoa(logger::PastLastSlash<__FILE__>::kArr), \
+                         logger::zatoa("]: [DD] "), logger::zatoa(_fmt))       \
+                                                                               \
+            .data() __VA_OPT__(, ) __VA_ARGS__);                               \
+  } while (false)
 
 #ifdef NDEBUG
 #define TRACE(...) \
   { ; }
 #else
-#define TRACE(_fmt, ...)                                            \
-  do {                                                              \
-    logger.Trace(std::format("[{}:{}:{}]: " _fmt, __func__,         \
-                             _basename(__FILE__),                   \
-                             __LINE__ __VA_OPT__(, ) __VA_ARGS__)); \
-  } while (false);
+#define TRACE(_fmt, ...)                                                       \
+  do {                                                                         \
+    logger.Trace(                                                              \
+        logger::zstrcats(logger::zatoa("[" __FILE__ ":" QUOTE(__LINE__) ":"),  \
+                         logger::zatoa(logger::PastLastSlash<__FILE__>::kArr), \
+                         logger::zatoa("]: [TT] "), logger::zatoa(_fmt))       \
+                                                                               \
+            .data() __VA_OPT__(, ) __VA_ARGS__);                               \
+  } while (false)
+
 #endif
 
 #endif  // TH2_LOGUTIL_H

--- a/logutil/logutil.h
+++ b/logutil/logutil.h
@@ -554,8 +554,9 @@ auto static get() noexcept -> Logger & {
 
         close(shm_fd);
 
-        auto prev_logger = *reinterpret_cast<std::shared_ptr<Logger> *>(
-            mmapped_shm + kOffLogger);
+        auto prev_logger = std::shared_ptr<Logger>(
+            *reinterpret_cast<std::shared_ptr<Logger> *>(mmapped_shm +
+                                                         kOffLogger));
 
         auto *prev_queue =
             *reinterpret_cast<decltype(Logger::async_output_queue_) *>(

--- a/logutil/logutil.h
+++ b/logutil/logutil.h
@@ -61,7 +61,13 @@ namespace details {
 template <typename... Args>
 static inline auto fmt_args(auto &&fmt_str, Args &&...args) {
   return (std::vformat(std::forward<decltype(fmt_str)>(fmt_str),
-                       std::make_format_args(std::forward<Args>(args)...)));
+                       std::make_format_args(std::forward<Args &>(args)...)));
+}
+
+template <typename... Args>
+static inline auto fmt_args(const auto &fmt_str, Args &...args) {
+  return (std::vformat(std::forward<decltype(fmt_str)>(fmt_str),
+                       std::make_format_args(std::forward<Args &>(args)...)));
 }
 
 static constexpr auto kGetEnv = [](const char *env_var_name) {

--- a/logutil/logutil_example.cc
+++ b/logutil/logutil_example.cc
@@ -15,7 +15,6 @@
 #include <ctime>
 #include <filesystem>
 #include <format>
-#include <fstream>
 #include <random>
 #include <ranges>
 

--- a/logutil/logutil_example_dylib.cc
+++ b/logutil/logutil_example_dylib.cc
@@ -1,7 +1,6 @@
 #include "logutil.h"
+
 extern "C" void libmain() {
   auto &logger = Logger::get();
-  TRACE(
-      "from example dylib: should inherit verbosity level trace from main "
-      "shared obj");
+  WARN("vanilla C/C++ is not sufficient not handle the dlopen use case");
 }


### PR DESCRIPTION
# Summary

## Logger
-  (singleton) now propagated through mmapped POSIX shared-memory unique global instance
- lock free async IO
- with enhanced formatting and runtime assert dispatch helpers;
- has been running prod for 2 months
- dependencies:
 - curl now pulls explicitly via vcpkg
 - c++20 ranges aren't cutting it, use range-v3

## `INTST`
Diffing ([JSON Patch (RFC6902)](https://datatracker.ietf.org/doc/html/rfc6902/) formatted)  state snapshot output  to optionally comparessed stream

-  Explicit eras signalling by client
- May be configured at runtime or not
- singleton propagated by same POSIX shm/mmap mechanism